### PR TITLE
Add Jest unit tests

### DIFF
--- a/__tests__/addResources.test.ts
+++ b/__tests__/addResources.test.ts
@@ -1,0 +1,29 @@
+import { addExp } from '../util/addExp';
+import { addGold } from '../util/addGold';
+
+global.fetch = jest.fn();
+const mockFetch = global.fetch as jest.Mock;
+
+describe('resource utilities', () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ ok: true }) } as any);
+  });
+
+  afterEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it('addExp posts to API', async () => {
+    await addExp(5);
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/update', expect.objectContaining({
+      method: 'PUT',
+    }));
+  });
+
+  it('addGold posts to API', async () => {
+    await addGold(10);
+    expect(mockFetch).toHaveBeenCalledWith('/api/profile/update', expect.objectContaining({
+      method: 'PUT',
+    }));
+  });
+});

--- a/__tests__/calculateDaysForLevel.test.ts
+++ b/__tests__/calculateDaysForLevel.test.ts
@@ -1,0 +1,11 @@
+import { calculateDaysForLevel } from '../util/calculateDaysForLevel';
+
+describe('calculateDaysForLevel', () => {
+  it('maps levels to days', () => {
+    expect(calculateDaysForLevel(0, null)).toBe(0);
+    expect(calculateDaysForLevel(1, null)).toBeCloseTo(3.1);
+    expect(calculateDaysForLevel(2, null)).toBeCloseTo(4.1);
+    expect(calculateDaysForLevel(3, null)).toBeCloseTo(6.1);
+    expect(calculateDaysForLevel(4, null)).toBeCloseTo(8.1);
+  });
+});

--- a/__tests__/calculateGold.test.ts
+++ b/__tests__/calculateGold.test.ts
@@ -1,0 +1,25 @@
+import { calculateGoldReward, GoldCalculationConfig } from '../lib/calculateGold';
+
+describe('calculateGoldReward', () => {
+  const baseReview: any = {
+    obedience: 3,
+    vibeDuringSex: 3,
+    vibeAfterSex: 3,
+    orgasmIntensity: 3,
+    painlessness: 3,
+    ballsWorshipping: 3,
+    cumWorshipping: 3,
+    didEverythingForHisPleasure: 3,
+    didSquirt: false,
+    wasAnal: false,
+  };
+
+  it('calculates default reward', () => {
+    expect(calculateGoldReward(baseReview)).toBe(33);
+  });
+
+  it('applies extra bonus percentages', () => {
+    const config: GoldCalculationConfig = { extraBonusPercentages: [0.1] };
+    expect(calculateGoldReward(baseReview, config)).toBe(36);
+  });
+});

--- a/__tests__/calculateLevel.test.ts
+++ b/__tests__/calculateLevel.test.ts
@@ -1,0 +1,16 @@
+import { calculateLevel } from '../util/calculateLevel';
+
+describe('calculateLevel', () => {
+  it('returns 0 for new entries', () => {
+    const createdAt = new Date();
+    expect(calculateLevel(createdAt, null)).toBe(0);
+  });
+
+  it('respects thresholds', () => {
+    const days = (n: number) => new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+    expect(calculateLevel(days(4), null)).toBe(1);
+    expect(calculateLevel(days(5), null)).toBe(2);
+    expect(calculateLevel(days(7), null)).toBe(3);
+    expect(calculateLevel(days(9), null)).toBe(4);
+  });
+});

--- a/__tests__/eventUtils.test.ts
+++ b/__tests__/eventUtils.test.ts
@@ -1,0 +1,23 @@
+import { getRecurringEventOccurrences } from '../util/eventUtils';
+import { IEvent } from '../models/Event';
+
+describe('getRecurringEventOccurrences', () => {
+  const baseEvent: IEvent = {
+    _id: '1',
+    title: 'Test',
+    description: 'D',
+    startDate: new Date('2023-01-01T00:00:00Z'),
+    endDate: new Date('2023-01-01T01:00:00Z'),
+    recurring: true,
+    recurrence: 'daily',
+  } as any;
+
+  it('generates occurrences within window', () => {
+    const start = new Date('2023-01-02T00:00:00Z');
+    const end = new Date('2023-01-04T00:00:00Z');
+    const occ = getRecurringEventOccurrences(baseEvent, start, end);
+    expect(occ).toHaveLength(3);
+    expect(occ[0].startDate.toISOString()).toBe('2023-01-02T00:00:00.000Z');
+    expect(occ[2].startDate.toISOString()).toBe('2023-01-04T00:00:00.000Z');
+  });
+});

--- a/__tests__/telegram.test.ts
+++ b/__tests__/telegram.test.ts
@@ -1,0 +1,14 @@
+import { sendTelegramMessage } from '../util/sendTelegramMessage';
+
+global.fetch = jest.fn();
+const mockFetch = global.fetch as jest.Mock;
+
+describe('sendTelegramMessage', () => {
+  it('posts message to API', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) } as any);
+    await sendTelegramMessage('user', 'hi');
+    expect(mockFetch).toHaveBeenCalledWith('/api/sendMessage', expect.objectContaining({
+      method: 'POST',
+    }));
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,11 @@
+import { cn } from '../lib/utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('allows duplicate class names', () => {
+    expect(cn('foo', 'bar', 'foo')).toBe('foo bar foo');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@bsmnt/scrollytelling": "^0.3.3",
@@ -70,15 +71,18 @@
     "@types/cookies": "^0.9.0",
     "@types/file-saver": "^2.0.7",
     "@types/formidable": "^3.4.5",
+    "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^20",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.1.6",
+    "jest": "^29.7.0",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
+    "ts-jest": "^29.3.4",
     "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest configuration
- integrate Jest test script in `package.json`
- add unit tests for helper utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684089850308832da4550d5a4a2bc294